### PR TITLE
Include all sub packages

### DIFF
--- a/lens/setup.py
+++ b/lens/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='lens_metric',
@@ -9,7 +9,7 @@ setup(
     url='https://github.com/Yao-Dou/LENS',
     download_url='https://github.com/Yao-Dou/LENS/archive/refs/tags/v0.1.0.tar.gz',
     license='Apache license',
-    packages=['lens'],
+    packages=find_packages(),
     install_requires=[
         "sentencepiece==0.1.96",
         "pandas==1.1.5",


### PR DESCRIPTION
Hey,

I installed it via `pip install` but it only adds the root file:

> ModuleNotFoundError: No module named 'lens.models'

![image](https://user-images.githubusercontent.com/20790833/235481765-0052ce7c-320f-4de7-a3e2-e58c6fa9d550.png)

With this, it's fixed 😄 