### PR TITLE
Add support for cpu

### DIFF
--- a/lens/lens/lens_score.py
+++ b/lens/lens/lens_score.py
@@ -6,10 +6,11 @@ class LENS:
     def __init__(
             self, 
             path: str, 
-            rescale: bool = False
+            rescale: bool = False,
+            map_location: any = None
         ):
         self.rescale = rescale
-        self.model = load_from_checkpoint(path)
+        self.model = load_from_checkpoint(path, map_location=map_location)
 
     def score(
             self, 
@@ -17,7 +18,8 @@ class LENS:
             simplified: list[str], 
             references: list[list[str]], 
             batch_size: int = 16, 
-            devices: list[int] = None
+            devices: list[int] = None,
+            accelerator: str = None,
         ):
         all_data = []
         for com, hyp, refs in zip(complex, simplified, references):
@@ -28,7 +30,8 @@ class LENS:
         prediction = self.model.predict(
             all_data, 
             batch_size=batch_size, 
-            devices=devices
+            devices=devices,
+            accelerator=accelerator,
         )
         orig_scores = prediction.scores
 
@@ -56,9 +59,10 @@ class LENS:
 class LENS_SALSA:
     def __init__(
             self, 
-            path: str
+            path: str,
+            map_location: any = None
         ):
-        self.model = load_from_checkpoint(path)
+        self.model = load_from_checkpoint(path, map_location=map_location)
         self.use_references = False
 
         self.target_column = self.model.target_column
@@ -140,7 +144,8 @@ class LENS_SALSA:
             simplified: list[str], 
             references: list[list[str]] = None, 
             batch_size: int = 16, 
-            devices: list[int] = None
+            devices: list[int] = None,
+            accelerator: str = None,
         ):
         if references:
             # Reference eval
@@ -162,7 +167,8 @@ class LENS_SALSA:
         prediction = self.model.predict(
             all_data, 
             batch_size=batch_size, 
-            devices=devices
+            devices=devices,
+            accelerator=accelerator,
         )
 
         prediction.scores = [s*100 for s in prediction.scores]

--- a/lens/lens/models/__init__.py
+++ b/lens/lens/models/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Union
 
 import yaml
+import torch
 from huggingface_hub import snapshot_download
 
 from .regression_metric_multi_ref import RegressionMetricMultiReference
@@ -41,7 +42,7 @@ def download_model(
     return checkpoint_path
 
 
-def load_from_checkpoint(checkpoint_path: str) -> LensModel:
+def load_from_checkpoint(checkpoint_path: str, map_location=None) -> LensModel:
     """Loads models from a checkpoint path.
 
     Args:
@@ -50,6 +51,11 @@ def load_from_checkpoint(checkpoint_path: str) -> LensModel:
     Return:
         COMET model.
     """
+    if map_location is None:
+        map_location = 'cpu'
+        if torch.cuda.is_available():
+            map_location = 'gpu'
+
     checkpoint_path = Path(checkpoint_path)
 
     if not checkpoint_path.is_file():
@@ -66,7 +72,7 @@ def load_from_checkpoint(checkpoint_path: str) -> LensModel:
         #     checkpoint_path, load_pretrained_weights=False, strict=False
         # )
         model = model_class.load_from_checkpoint(
-            checkpoint_path, **hparams, strict=False
+            checkpoint_path, **hparams, strict=False, map_location=map_location
         )
         return model
     else:

--- a/lens/lens/models/__init__.py
+++ b/lens/lens/models/__init__.py
@@ -54,7 +54,7 @@ def load_from_checkpoint(checkpoint_path: str, map_location=None) -> LensModel:
     if map_location is None:
         map_location = 'cpu'
         if torch.cuda.is_available():
-            map_location = 'gpu'
+            map_location = 'cuda'
 
     checkpoint_path = Path(checkpoint_path)
 

--- a/lens/lens/models/base.py
+++ b/lens/lens/models/base.py
@@ -555,7 +555,7 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
         mc_dropout: int = 0,
         progress_bar: bool = True,
         accelerator: str = None,
-        num_workers: int = None,
+        num_workers: int = 0,
         length_batching: bool = True,
     ) -> Prediction:
         """Method that receives a list of samples (dictionaries with translations,
@@ -575,7 +575,7 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             accelerator (str): Pytorch Lightning accelerator (e.g: 'cpu', 'cuda', 'hpu'
                 , 'ipu', 'mps', 'tpu'). Defaults to 'auto'
             num_workers (int): Number of workers to use when loading and preparing
-                data. Defaults to None
+                data. Defaults to 0.
             length_batching (bool): If set to true, reduces padding by sorting samples
                 by sequence length. Defaults to True.
 

--- a/lens/lens/models/base.py
+++ b/lens/lens/models/base.py
@@ -554,7 +554,7 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
         devices: Union[List[int], str, int] = None,
         mc_dropout: int = 0,
         progress_bar: bool = True,
-        accelerator: str = "auto",
+        accelerator: str = None,
         num_workers: int = None,
         length_batching: bool = True,
     ) -> Prediction:
@@ -572,7 +572,7 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             mc_dropout (int): Number of inference steps to run using MCD. Defaults to 0
             progress_bar (bool): Flag that turns on and off the predict progress bar.
                 Defaults to True
-            accelarator (str): Pytorch Lightning accelerator (e.g: 'cpu', 'cuda', 'hpu'
+            accelerator (str): Pytorch Lightning accelerator (e.g: 'cpu', 'cuda', 'hpu'
                 , 'ipu', 'mps', 'tpu'). Defaults to 'auto'
             num_workers (int): Number of workers to use when loading and preparing
                 data. Defaults to None
@@ -583,36 +583,44 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             Prediction object with `scores`, `system_score` and any metadata returned
                 by the model.
         """
-        # Don't use all GPUs if there are less samples than GPUs
-        if devices and len(devices) > 0:
-          # Don't use all GPUs if there are less samples than GPUs
-          if len(samples) < len(devices): 
-              devices = range(len(samples))
-          gpus = len(devices)
-        else:
-          gpus = 0
+        if devices is None:
+            devices = "auto"
+        if accelerator is None:
+            accelerator = "auto"
+
+        multi_gpu = False
+        # If using more than 2 GPUs, multiple process are created and need
+        #  some sheananigans. Also, ensuring that there is more samples than
+        #  gpus.
+        if accelerator == "gpu":
+            if isinstance(devices, list):
+                devices = devices[:len(samples)]
+                n_gpus = len(devices)
+            elif isinstance(devices, int):
+                devices = min(devices, len(samples))
+                n_gpus = devices
+            elif devices is None or devices == "auto":
+                n_gpus = torch.cuda.device_count()
+
+            if n_gpus > 1:
+                multi_gpu = True
+                num_workers = 2 * max(n_gpus)
         
+        callbacks = []
+        if multi_gpu:
+            pred_writer = CustomWriter()
+            callbacks = [pred_writer]
+
         if mc_dropout > 0:
             self.set_mc_dropout(mc_dropout)
 
-        if devices is not None:
-            assert len(devices) == gpus, AssertionError(
-                "List of devices must be same size as `gpus`"
-            )
-        else:
-            devices = gpus if gpus > 0 else None
-
         sampler = SequentialSampler(samples)
-        if length_batching and gpus < 2:
+        if length_batching and not multi_gpu:
             try:
                 sort_ids = np.argsort([len(sample["src"]) for sample in samples])
             except KeyError:
                 sort_ids = np.argsort([i for i, sample in enumerate(samples)])
             sampler = OrderedSampler(sort_ids)
-
-        if num_workers is None:
-            # Guideline for workers that typically works well.
-            num_workers = 2 * gpus
 
         self.eval()
         dataloader = DataLoader(
@@ -622,14 +630,6 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             collate_fn=self.prepare_for_inference,
             num_workers=num_workers,
         )
-        if gpus > 1:
-            pred_writer = CustomWriter()
-            callbacks = [pred_writer]
-        else:
-            callbacks = []
-
-        if gpus == 0: 
-          devices = 'auto'
 
         if progress_bar:
             enable_progress_bar = True
@@ -646,25 +646,25 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             devices=devices,
             logger=False,
             callbacks=callbacks,
-            accelerator=accelerator if gpus > 0 else "cpu",
+            accelerator=accelerator,
             strategy="auto",
             enable_progress_bar=enable_progress_bar,
         )
-        return_predictions = False if gpus > 1 else True
+        return_predictions = False if multi_gpu else True
         predictions = trainer.predict(
             self, dataloaders=dataloader, return_predictions=return_predictions
         )
-        if gpus > 1:
+        if multi_gpu:
             torch.distributed.barrier()  # Waits for all processes to finish predict
 
         # If we are in the GLOBAL RANK we need to gather all predictions
-        if gpus > 1 and trainer.is_global_zero:
+        if multi_gpu and trainer.is_global_zero:
             predictions = pred_writer.gather_all_predictions()
             # Delete Temp folder.
             pred_writer.cleanup()
             return predictions
 
-        elif gpus > 1 and not trainer.is_global_zero:
+        elif multi_gpu and not trainer.is_global_zero:
             # If we are not in the GLOBAL RANK we will return None
             exit()
 
@@ -674,7 +674,7 @@ class LensModel(ptl.LightningModule, metaclass=abc.ABCMeta):
         else:
             metadata = []
 
-        if length_batching and gpus < 2:
+        if length_batching and not multi_gpu:
             scores = restore_list_order(scores, sort_ids)
             output = Prediction(scores=scores, system_score=sum(scores) / len(scores))
             if metadata:


### PR DESCRIPTION
I added a map_location argument in LENS to allow user to choose which device to use, as well as a mechanism to automagically choose between cuda and cpu by default. Fixes #17 
I tried to simplify the logic for multi-gpu, workers, cpu, devices and accelerator in LENS.score. By default everything is automatic, but user can pass argumenhts  for finer control.

I wasn't able to test the code when > 2 GPUs are available because of the following error:
```
RuntimeError: Lightning can't create new processes if CUDA is already initialized. Did you manually call `torch.cuda.*` functions, have moved the model to the device, or allocated memory on the GPU any other way? Please remove any such calls, or change the selected strategy. You will have to restart the Python kernel.
```
which already happens in the original code. Even when getting rid of `torch.cuda.*` calls the error persists.
To bypass this error I pass `devices=[0]` to LENS.score so it only uses 1 GPU.

Code was tested on a Mac with MPS, a Mac with CPU only, Ubuntu Server with 2 gpus.

<details>
<summary>The test I used was:</summary>

```python
from lens import download_model, LENS

lens_path = download_model("davidheineman/lens")

# Original LENS is a real-valued number. 
# Rescaled version (rescale=True) rescales LENS between 0 and 100 for better interpretability. 
# You can also use the original version using rescale=False
lens = LENS(lens_path, rescale=True)
print(f'LENS is loaded on : {lens.model.device.type}')

complex = [
    "They are culturally akin to the coastal peoples of Papua New Guinea."
]
simple = [
    "They are culturally similar to the people of Papua New Guinea."
]
references = [[
    "They are culturally similar to the coastal peoples of Papua New Guinea.",
    "They are similar to the Papua New Guinea people living on the coast."
]]

print('By default uses:')
scores = lens.score(complex, simple, references)
print('With acc = cpu')
scores = lens.score(complex, simple, references, accelerator="cpu")
print('With acc = gpu')
scores = lens.score(complex, simple, references, accelerator="gpu")

# Testing SALSA
from lens import download_model, LENS_SALSA

lens_salsa_path = download_model("davidheineman/lens-salsa")
lens_salsa = LENS_SALSA(lens_salsa_path)
print(f'LENS is loaded on : {lens_salsa.model.device.type}')

complex = [
    "They are culturally akin to the coastal peoples of Papua New Guinea.",
]
simple = [
    "They are culturally similar to the people of Papua New Guinea.",
]
print('By default uses:')
scores, word_level_scores = lens_salsa.score(complex, simple, devices=[0])
print('With acc = cpu')
scores, word_level_scores = lens_salsa.score(complex, simple, accelerator="cpu")
print('With acc = gpu')
scores, word_level_scores = lens_salsa.score(complex, simple, accelerator="gpu", devices=[0])
```
</details>